### PR TITLE
Docs - Fix link to Foxx docs, add link to repo, line wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ foxx server --help # Help for the "server" command
 foxx server list --help # Subcommands are supported, too
 ```
 
-If you have no prior knowledge of Foxx, you can get started by [installing ArangoDB locally](https://www.arangodb.com/download) and then creating a new Foxx service in the current directory using the `init` command:
+If you have no prior knowledge of Foxx, you can get started by
+[installing ArangoDB locally](https://www.arangodb.com/download) and then
+creating a new Foxx service in the current directory using the `init` command:
 
 ```sh
 foxx init -i # answer the interactive questions
@@ -91,7 +93,8 @@ foxx init -e # create an example service please
 
 You can also just use `foxx init` to create a minimal service without the example code.
 
-You can inspect the files created by the program and tweak them as necessary. Once you're ready, install the service at a _mount path_ using the `install` command:
+You can inspect the files created by the program and tweak them as necessary.
+Once you're ready, install the service at a _mount path_ using the `install` command:
 
 ```sh
 foxx install /hello-foxx # installs the current directory
@@ -101,7 +104,8 @@ You should then be able to view the installed service in your browser at the fol
 
 <http://localhost:8529/_db/_system/hello-foxx>
 
-If you continue to work on your Foxx service and want to upgrade the installed version with your local changes use the `upgrade` command to do so.
+If you continue to work on your Foxx service and want to upgrade the installed
+version with your local changes use the `upgrade` command to do so.
 
 ```sh
 foxx upgrade /hello-foxx # upgrades the server with the current directory
@@ -112,8 +116,8 @@ foxx upgrade /hello-foxx # upgrades the server with the current directory
 ### manifest.json
 
 The `manifest.json` or manifest file contains a service's meta-information. For
-more information on the manifest format, see the
-[official ArangoDB documentation](https://docs.arangodb.com/3/Manual/Foxx/Manifest.html).
+more information on the manifest format, see the official
+[Foxx documentation](https://docs.arangodb.com/3.3/Manual/Foxx/Manifest.html).
 
 The directory containing a service's `manifest.json` file is called the _root
 directory_ of the service.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 To learn more about Foxx, see the
 [official ArangoDB Foxx documentation](https://docs.arangodb.com/latest/Manual/Foxx/).
 
+The minimum ArangoDB server version is 3.2.0, which introduced the
+[Foxx HTTP API](https://docs.arangodb.com/latest/HTTP/Foxx/).
+
 ## Table of Contents
 
 * [Install](#install)

--- a/docs/Manual/Programs/FoxxCLI/Details.md
+++ b/docs/Manual/Programs/FoxxCLI/Details.md
@@ -1,5 +1,7 @@
 # Foxx CLI Details
 
+Repository: https://github.com/arangodb/foxx-cli/
+
 ## Install
 
 **foxx-cli** runs on [Node.js](https://nodejs.org) and can be installed with
@@ -49,7 +51,9 @@ foxx server --help # Help for the "server" command
 foxx server list --help # Subcommands are supported, too
 ```
 
-If you have no prior knowledge of Foxx, you can get started by [installing ArangoDB locally](https://www.arangodb.com/download) and then creating a new Foxx service in the current directory using the `init` command:
+If you have no prior knowledge of Foxx, you can get started by
+[installing ArangoDB locally](https://www.arangodb.com/download) and then
+creating a new Foxx service in the current directory using the `init` command:
 
 ```sh
 foxx init -i # answer the interactive questions
@@ -63,7 +67,8 @@ foxx init -e # create an example service please
 
 You can also just use `foxx init` to create a minimal service without the example code.
 
-You can inspect the files created by the program and tweak them as necessary. Once you're ready, install the service at a _mount path_ using the `install` command:
+You can inspect the files created by the program and tweak them as necessary.
+Once you're ready, install the service at a _mount path_ using the `install` command:
 
 ```sh
 foxx install /hello-foxx # installs the current directory
@@ -73,7 +78,8 @@ You should then be able to view the installed service in your browser at the fol
 
 <http://localhost:8529/_db/_system/hello-foxx>
 
-If you continue to work on your Foxx service and want to upgrade the installed version with your local changes use the `upgrade` command to do so.
+If you continue to work on your Foxx service and want to upgrade the installed
+version with your local changes use the `upgrade` command to do so.
 
 ```sh
 foxx upgrade /hello-foxx # upgrades the server with the current directory
@@ -84,8 +90,8 @@ foxx upgrade /hello-foxx # upgrades the server with the current directory
 ### manifest.json
 
 The `manifest.json` or manifest file contains a service's meta-information. For
-more information on the manifest format, see the
-[official ArangoDB documentation](https://docs.arangodb.com/3/Manual/Foxx/Manifest.html).
+more information on the manifest format, see the official
+[Foxx documentation](https://docs.arangodb.com/3.3/Manual/Foxx/Manifest.html).
 
 The directory containing a service's `manifest.json` file is called the _root
 directory_ of the service.

--- a/docs/Manual/Programs/FoxxCLI/README.md
+++ b/docs/Manual/Programs/FoxxCLI/README.md
@@ -7,3 +7,6 @@ can be installed via the package managers NPM and Yarn.
 It is the successor of `foxx-manager`, which is deprecated and will be
 removed eventually. Also see [Foxx Deployment](../../Foxx/Deployment.md)
 for additional deployment options.
+
+The minimum ArangoDB server version is 3.2.0, which introduced the
+[Foxx HTTP API](../../../HTTP/Foxx/index.html).


### PR DESCRIPTION
We may need to change this link again to something like `/latest`, but we first need to migrate the docs to Pantheon and handle missing pages more gracefully (which should allow us to substitute `/latest` with the current GA documentation, and if it's not there anymore, try the parent folders to find something close to it).